### PR TITLE
Add implementation for mpg123_seek, mpg123_seek_frame and mpg123_timeframe

### DIFF
--- a/mpg123.go
+++ b/mpg123.go
@@ -103,7 +103,23 @@ func (rsc *Mp3ReaderSeekerCloser) Read(p []byte) (int, error) {
 }
 
 func (rsc *Mp3ReaderSeekerCloser) Seek(offset int64, whence int) (int64, error) {
-	return 0, nil
+	c_offset := (C.off_t)(offset)
+	c_whence := (C.int)(whence)
+	s_offset := (int64)(C.mpg123_seek(rsc.handle, c_offset, c_whence))
+	return s_offset, nil
+}
+
+func (rsc *Mp3ReaderSeekerCloser) SeekFrame(offset int64, whence int) int64 {
+	c_offset := (C.off_t)(offset)
+	c_whence := (C.int)(whence)
+	s_offset := (int64)(C.mpg123_seek_frame(rsc.handle, c_offset, c_whence))
+	return s_offset
+}
+
+func (rsc *Mp3ReaderSeekerCloser) Timeframe(seconds int64) int64 {
+	c_seconds := (C.double)(seconds)
+	s_offset := (int64)(C.mpg123_timeframe(rsc.handle, c_seconds))
+	return s_offset
 }
 
 func (rsc *Mp3ReaderSeekerCloser) Close() error {


### PR DESCRIPTION
Hi,

I added a few implementations, however no idea if those require error handling; as far as I went through the mpg123 api reference they shouldn't need any.